### PR TITLE
Ensure all swapchains have a unique handle

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -321,6 +321,7 @@ struct Swapchain {
 static Instance g_instance{};
 static Session g_session{};
 static std::unordered_map<XrSwapchain, Swapchain> g_swapchains;
+uintptr_t g_nextSwapchainHandle = 1;
 
 // Head tracking state for mouse look and WASD movement
 static XrVector3f g_headPos = {0.0f, 1.7f, 0.0f};  // Start at standing eye height
@@ -1302,7 +1303,7 @@ static XrResult XRAPI_PTR xrCreateSwapchain_runtime(XrSession, const XrSwapchain
     Log("[SimXR] ============================================");
     if (!ci || !sc) return XR_ERROR_VALIDATION_FAILURE;
     rt::Swapchain chain{}; 
-    chain.handle = (XrSwapchain)(uintptr_t)(rt::g_swapchains.size() + 2);
+    chain.handle = (XrSwapchain)(rt::g_nextSwapchainHandle++);
     chain.format = (DXGI_FORMAT)ci->format;  // Store the original requested format
     chain.width = ci->width; 
     chain.height = ci->height; 


### PR DESCRIPTION
The previous approach is incorrect when multiple swapchains are created, destroyed, then recreated - it can lead to a new swapchain being assigned an existing handle, then overwriting that existing swapchain's data and thus corrupting further operations with the swapchains.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarantees unique swapchain handles to prevent overwriting entries after create/destroy/recreate cycles. This removes handle reuse and stops swapchain data corruption.

- **Bug Fixes**
  - Replaced `(g_swapchains.size() + 2)` with a monotonic counter `g_nextSwapchainHandle++` (initialized at `1`) for `chain.handle` assignment.

<sup>Written for commit 53cbf0704538ec1660ab2edbecd24350185c77fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

